### PR TITLE
Fix JSON code by avoiding datetime conversion

### DIFF
--- a/1-hypothesis-fn-neuron/2-plotting-a-neuron.ipynb
+++ b/1-hypothesis-fn-neuron/2-plotting-a-neuron.ipynb
@@ -1118,7 +1118,7 @@
     "import plotly.graph_objects as go\n",
     "import pandas as pd\n",
     "sugar_data_json = \"https://storage.googleapis.com/curriculum-assets/nn-from-scratch/sugar_data_fig.json\"\n",
-    "fig_dict = dict(pd.read_json(sugar_data_json, typ = 'dict'))\n",
+    "fig_dict = dict(pd.read_json(sugar_data_json, typ = 'dict', convert_dates=False))\n",
     "go.Figure(fig_dict)"
    ]
   },
@@ -2165,7 +2165,7 @@
     "import plotly.graph_objects as go\n",
     "import pandas as pd\n",
     "json_file = \"https://storage.googleapis.com/curriculum-assets/nn-from-scratch/sugar_fig_hyp.json\"\n",
-    "fig_dict = dict(pd.read_json(json_file, typ = 'dict'))\n",
+    "fig_dict = dict(pd.read_json(json_file, typ = 'dict', convert_dates=False))\n",
     "go.Figure(fig_dict)"
    ]
   },
@@ -5476,7 +5476,7 @@
    "source": [
     "import plotly.graph_objects as go\n",
     "cancer_json = \"https://storage.googleapis.com/curriculum-assets/nn-from-scratch/cancer_logistic.json\"\n",
-    "fig_dict = dict(pd.read_json(cancer_json, typ = 'dict'))\n",
+    "fig_dict = dict(pd.read_json(cancer_json, typ = 'dict', convert_dates=False))\n",
     "go.Figure(fig_dict)"
    ]
   },
@@ -8849,7 +8849,7 @@
     "import plotly.graph_objects as go\n",
     "\n",
     "cancer_json = \"https://storage.googleapis.com/curriculum-assets/nn-from-scratch/cancer_logistic.json\"\n",
-    "fig_dict = dict(pd.read_json(cancer_json, typ = 'dict'))\n",
+    "fig_dict = dict(pd.read_json(cancer_json, typ = 'dict', convert_dates=False))\n",
     "go.Figure(fig_dict)"
    ]
   },
@@ -12112,7 +12112,7 @@
    ],
    "source": [
     "weighted_sums_json = \"https://storage.googleapis.com/curriculum-assets/nn-from-scratch/weighted_sum_cancer.json\"\n",
-    "weighted_dict = dict(pd.read_json(weighted_sums_json, typ = 'dict'))\n",
+    "weighted_dict = dict(pd.read_json(weighted_sums_json, typ = 'dict', convert_dates=False))\n",
     "go.Figure(weighted_dict)"
    ]
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39412876/92633207-5a44df00-f2ca-11ea-8022-5277e5d08ce0.png)

I didn't test it with the non-sugar data sets, but I think it should be fine.